### PR TITLE
fix: Restrict libabseil on macOS given bug

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -108,7 +108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.1.5-py313h2cdc120_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-26_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.11.1-h73640d1_0.conda
@@ -517,21 +517,21 @@ packages:
   license_family: Apache
   size: 1309370
   timestamp: 1735453911208
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_2.conda
-  sha256: 12b85cd25bd82bb2255f329b37f974b3035a109d6345b6fb762b633c845014f9
-  md5: d97db28b64404efd1413d5c52f79cdae
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_hf9b8971_1.conda
+  sha256: 90bf08a75506dfcf28a70977da8ab050bcf594cd02abd3a9d84a22c9e8161724
+  md5: 706da5e791c569a7b9814877098a6a0a
   depends:
   - __osx >=11.0
-  - libcxx >=18
+  - libcxx >=17
   constrains:
-  - abseil-cpp =20240722.0
   - libabseil-static =20240722.0=cxx17*
+  - abseil-cpp =20240722.0
   arch: arm64
   platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 1173485
-  timestamp: 1735454097554
+  size: 1179072
+  timestamp: 1727295571173
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-26_linux64_openblas.conda
   build_number: 26
   sha256: 30bd658682b124243f8e52d8edf8a19e7be1bc31e4fe4baec30a64002dc8cd0c

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,3 +21,7 @@ cuda = "12.0"
 [dependencies]
 pytorch = ">=2.5.1,<3"
 curl = ">=8.11.1,<9"
+
+[target.osx.dependencies]
+# c.f. https://github.com/conda-forge/pytorch-cpu-feedstock/issues/311
+libabseil = { version = ">=20240722.0,<20240723", build-number = "==1" }


### PR DESCRIPTION
Temporary workaround for Issue #3.

* Restrict `libabseil` on macOS to `20240722.0` `build_number` `1` given bug.
   - c.f. https://github.com/conda-forge/pytorch-cpu-feedstock/issues/311