### PR TITLE
docs: Add warning on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On a Linux (`linux-64`) or Apple silicon (`osx-arm64`) machine install a GPU ena
 ## Get started
 
 > [!CAUTION]
-> If on macOS and using `pixi` `v0.39.4` or later you'll need to comment out or remove the `system-requirements table` given https://github.com/prefix-dev/pixi/issues/2714.
+> If on macOS and using `pixi` `v0.39.4` or earlier you'll need to comment out or remove the `system-requirements table` given https://github.com/prefix-dev/pixi/issues/2714.
 
 1. Install [`pixi`](https://pixi.sh/)
 2. Run

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On a Linux (`linux-64`) or Apple silicon (`osx-arm64`) machine install a GPU ena
 ## Get started
 
 > [!CAUTION]
-> If on macOS and using `pixi` `v0.39.4` or earlier you'll need to comment out or remove the `system-requirements table` given https://github.com/prefix-dev/pixi/issues/2714.
+> If on macOS and using `pixi` `v0.39.4` or earlier you'll need to comment out or remove the `system-requirements` table given https://github.com/prefix-dev/pixi/issues/2714.
 
 1. Install [`pixi`](https://pixi.sh/)
 2. Run

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ On a Linux (`linux-64`) or Apple silicon (`osx-arm64`) machine install a GPU ena
 
 ## Get started
 
+> [!CAUTION]
+> If on macOS and using `pixi` `v0.39.4` or later you'll need to comment out or remove the `system-requirements table` given https://github.com/prefix-dev/pixi/issues/2714.
+
 1. Install [`pixi`](https://pixi.sh/)
 2. Run
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -15,7 +15,7 @@ python torch_detect_GPU.py
 start = { depends-on = ["detect-gpu"] }
 
 [system-requirements]
-# pixi knows to ignore this for macOS
+# pixi v0.39.5+ knows to ignore this for macOS
 cuda = "12.0"
 
 [dependencies]


### PR DESCRIPTION
* Add warning on macOS to remove `system-requirements` table to avoid Issue #2.
   - c.f. https://github.com/prefix-dev/pixi/issues/2714