### PR TITLE
chore: Remove mention of minimum pixi version for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On a Linux (`linux-64`) or Apple silicon (`osx-arm64`) machine install a GPU ena
 ## Get started
 
 > [!CAUTION]
-> If on macOS and using `pixi` `v0.39.4` or earlier you'll need to comment out or remove the `system-requirements` table given https://github.com/prefix-dev/pixi/issues/2714.
+> If on macOS you'll need to comment out or remove the `system-requirements` table given https://github.com/prefix-dev/pixi/issues/2714.
 
 1. Install [`pixi`](https://pixi.sh/)
 2. Run

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,8 +14,8 @@ python torch_detect_GPU.py
 
 start = { depends-on = ["detect-gpu"] }
 
+# Need to remove this for macOS
 [system-requirements]
-# pixi v0.39.5+ knows to ignore this for macOS
 cuda = "12.0"
 
 [dependencies]


### PR DESCRIPTION
* The bug for macOS hasn't been resolved yet and it isn't clear what pixi version will be the target release to fix it.
* c.f. Issue https://github.com/matthewfeickert/pytorch-gpu-pixi-example/issues/2