### PR TITLE
chore: Add requires-pixi workspace spec

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,9 +1,10 @@
-[project]
+[workspace]
 authors = ["Matthew Feickert <matthew.feickert@cern.ch>"]
 channels = ["conda-forge"]
 description = "Example of CUDA/MPS enabled PyTorch install with pixi"
 name = "pytorch-gpu-pixi-example"
 platforms = ["linux-64", "osx-arm64"]
+requires-pixi = ">=0.42.0"
 version = "0.1.0"
 
 [tasks]
@@ -14,7 +15,6 @@ python torch_detect_GPU.py
 
 start = { depends-on = ["detect-gpu"] }
 
-# Need to remove this for macOS
 [system-requirements]
 cuda = "12.0"
 


### PR DESCRIPTION
* Add `requires-pixi` workspace spec with minimum of Pixi `v0.42.0` to allow the `[system-requirements]` table to be ignored by non `linux-64` platforms.
   - c.f. https://pixi.sh/v0.44.0/reference/pixi_manifest/#requires-pixi-optional
   - c.f. https://github.com/prefix-dev/pixi/releases/tag/v0.42.0